### PR TITLE
Main menu: add save/load UI and feedback; pause save feedback; headless boot smoke test

### DIFF
--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,18 +1,18 @@
-mod hud;
-mod toast;
-mod inventory_screen;
-mod dialogue_box;
-mod shop_screen;
-mod crafting_screen;
-mod pause_menu;
-mod main_menu;
-mod input;
-mod transitions;
 mod audio;
 mod chest_screen;
+mod crafting_screen;
+mod dialogue_box;
+mod hud;
+mod input;
+mod inventory_screen;
+mod main_menu;
+mod pause_menu;
+mod shop_screen;
+mod toast;
+mod transitions;
 
-use bevy::prelude::*;
 use crate::shared::*;
+use bevy::prelude::*;
 
 // ═══════════════════════════════════════════════════════════════════════
 // SHARED FONT HANDLE — used by all UI text across every screen
@@ -35,10 +35,7 @@ impl Plugin for UiPlugin {
 
         // ─── AUDIO — music state resource + event handlers ───
         app.init_resource::<audio::MusicState>();
-        app.add_systems(
-            Update,
-            (audio::handle_play_sfx, audio::handle_play_music),
-        );
+        app.add_systems(Update, (audio::handle_play_sfx, audio::handle_play_music));
         app.add_systems(OnEnter(GameState::Playing), audio::start_game_music);
         app.add_systems(OnEnter(GameState::MainMenu), audio::start_menu_music);
 
@@ -71,6 +68,7 @@ impl Plugin for UiPlugin {
             (
                 main_menu::update_main_menu_visuals,
                 main_menu::main_menu_navigation,
+                main_menu::handle_load_complete_in_main_menu,
             )
                 .run_if(in_state(GameState::MainMenu)),
         );
@@ -110,27 +108,29 @@ impl Plugin for UiPlugin {
         // ─── GLOBAL INPUT — runs during Playing ───
         app.add_systems(
             Update,
-            (
-                input::global_input_handler,
-                input::hotbar_input_handler,
-            )
+            (input::global_input_handler, input::hotbar_input_handler)
                 .run_if(in_state(GameState::Playing)),
         );
         // Also run global_input_handler in overlay states for Escape to close
         app.add_systems(
             Update,
-            input::global_input_handler
-                .run_if(
-                    in_state(GameState::Inventory)
-                        .or(in_state(GameState::Shop))
-                        .or(in_state(GameState::Crafting))
-                        .or(in_state(GameState::Dialogue))
-                ),
+            input::global_input_handler.run_if(
+                in_state(GameState::Inventory)
+                    .or(in_state(GameState::Shop))
+                    .or(in_state(GameState::Crafting))
+                    .or(in_state(GameState::Dialogue)),
+            ),
         );
 
         // ─── INVENTORY SCREEN ───
-        app.add_systems(OnEnter(GameState::Inventory), inventory_screen::spawn_inventory_screen);
-        app.add_systems(OnExit(GameState::Inventory), inventory_screen::despawn_inventory_screen);
+        app.add_systems(
+            OnEnter(GameState::Inventory),
+            inventory_screen::spawn_inventory_screen,
+        );
+        app.add_systems(
+            OnExit(GameState::Inventory),
+            inventory_screen::despawn_inventory_screen,
+        );
         app.add_systems(
             Update,
             (
@@ -142,8 +142,14 @@ impl Plugin for UiPlugin {
         );
 
         // ─── DIALOGUE BOX ───
-        app.add_systems(OnEnter(GameState::Dialogue), dialogue_box::spawn_dialogue_box);
-        app.add_systems(OnExit(GameState::Dialogue), dialogue_box::despawn_dialogue_box);
+        app.add_systems(
+            OnEnter(GameState::Dialogue),
+            dialogue_box::spawn_dialogue_box,
+        );
+        app.add_systems(
+            OnExit(GameState::Dialogue),
+            dialogue_box::despawn_dialogue_box,
+        );
         app.add_systems(
             Update,
             dialogue_box::advance_dialogue.run_if(in_state(GameState::Dialogue)),
@@ -162,8 +168,14 @@ impl Plugin for UiPlugin {
         );
 
         // ─── CRAFTING SCREEN ───
-        app.add_systems(OnEnter(GameState::Crafting), crafting_screen::spawn_crafting_screen);
-        app.add_systems(OnExit(GameState::Crafting), crafting_screen::despawn_crafting_screen);
+        app.add_systems(
+            OnEnter(GameState::Crafting),
+            crafting_screen::spawn_crafting_screen,
+        );
+        app.add_systems(
+            OnExit(GameState::Crafting),
+            crafting_screen::despawn_crafting_screen,
+        );
         app.add_systems(
             Update,
             (
@@ -182,6 +194,7 @@ impl Plugin for UiPlugin {
             (
                 pause_menu::update_pause_menu_visuals,
                 pause_menu::pause_menu_navigation,
+                pause_menu::handle_save_complete_in_pause_menu,
             )
                 .run_if(in_state(GameState::Paused)),
         );


### PR DESCRIPTION
### Motivation

- Expose save/load flows from the Main Menu and provide user-visible status for load/save operations so players can start new games or load slots from the menu and see feedback for in-progress operations.
- Surface save slot metadata in the UI by scanning save files when the menu is shown so the Load dialog can display slot summaries and disabled/empty states.
- Provide a headless boot smoke test to verify data boot and basic ECS ticking without rendering.

### Description

- Update the save domain to scan slot metadata on entering `GameState::MainMenu` and allow `handle_load_request`/`handle_new_game` to run in the `MainMenu` state via the `SavePlugin` setup and `scan_save_slots` registration.
- Revamp `main_menu` to introduce `MainMenuState` with `mode`, `status_message`, and `pending_load_slot`, add `MainMenuMode::LoadSlots`, render dynamic menu items for `NUM_SAVE_SLOTS`, show a status text line, and send `LoadRequestEvent` when selecting an existing slot via `main_menu::main_menu_navigation`.
- Add `main_menu::handle_load_complete_in_main_menu` to listen for `LoadCompleteEvent` and transition to `GameState::Playing` on successful load (or show error text on failure).
- Update `pause_menu` to include a `status_message` and `PauseMenuStatusText`, to send `SaveRequestEvent` when saving, and add `handle_save_complete_in_pause_menu` to update the pause menu status on `SaveCompleteEvent`.
- Small refactors and formatting improvements in `src/save/mod.rs` (read/write formatting, `tick_session_timer` signature) and in `src/ui/mod.rs` for consistent `add_systems` registration formatting.
- Add a headless integration test `test_headless_boot_smoke_transitions_and_ticks` in `tests/headless.rs` that registers the `DataPlugin`, boots to `MainMenu`, asserts registries are populated, transitions to `Playing`, and runs a short frame loop to ensure no panics.

### Testing

- Ran the headless test suite with `cargo test --test headless`, which included `test_headless_boot_smoke_transitions_and_ticks` and the existing headless integration tests, and they all passed.
- Ran `cargo test` to execute unit and integration tests across the repo and observed the test suite completing successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0c74f896c8331a76a2b461ea3bcc9)