### PR TITLE
Fix WASM build: resolve wasm-bindgen segfault and optimize pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 /target
+/web
+/dist
+*.zip
 *.log
 logs/
 *.db

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2099,24 +2099,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures-task"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
-
-[[package]]
-name = "futures-util"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
-dependencies = [
- "futures-core",
- "futures-task",
- "pin-project-lite",
- "slab",
-]
-
-[[package]]
 name = "gethostname"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2507,9 +2489,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.90"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14dc6f6450b3f6d4ed5b16327f38fed626d375a886159ca555bd7822c0c3a5a6"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -4256,25 +4238,37 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.113"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60722a937f594b7fde9adb894d7c092fc1bb6612897c46368d18e7a20208eff2"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+dependencies = [
+ "bumpalo",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.63"
+version = "0.4.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a89f4650b770e4521aa6573724e2aed4704372151bd0de9d16a3bbabb87441a"
+checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
 dependencies = [
  "cfg-if",
- "futures-util",
  "js-sys",
  "once_cell",
  "wasm-bindgen",
@@ -4283,9 +4277,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.113"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fac8c6395094b6b91c4af293f4c79371c163f9a6f56184d2c9a85f5a95f3950"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4293,31 +4287,31 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.113"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3fabce6159dc20728033842636887e4877688ae94382766e00b180abac9d60"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
- "bumpalo",
  "proc-macro2",
  "quote",
  "syn",
+ "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.113"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de0e091bdb824da87dc01d967388880d017a0a9bc4f3bdc0d86ee9f9336e3bb5"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.90"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "705eceb4ce901230f8625bd1d665128056ccbe4b7408faa625eec1ba80f59a97"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,4 +24,4 @@ inherits = "release"
 opt-level = "z"
 lto = true
 codegen-units = 1
-strip = true
+# Note: strip=true removes wasm-bindgen custom sections; do NOT enable for WASM

--- a/build_wasm.sh
+++ b/build_wasm.sh
@@ -12,19 +12,38 @@ if ! command -v wasm-bindgen &>/dev/null; then
     cargo install wasm-bindgen-cli
 fi
 
-# Build release for WASM
-echo "Building release..."
-cargo build --release --target wasm32-unknown-unknown --profile wasm-release 2>/dev/null \
-  || cargo build --release --target wasm32-unknown-unknown
+# Build release for WASM (wasm-release profile: opt-level=z, LTO)
+echo "Building wasm-release..."
+cargo build --profile wasm-release --target wasm32-unknown-unknown
 
 # wasm-bindgen to generate JS glue
+# RAYON_NUM_THREADS=1 prevents rayon worker thread stack overflows
+# when walrus parses large WASM binaries (73K+ functions)
 echo "Running wasm-bindgen..."
 mkdir -p web
-wasm-bindgen \
+WASM_BIN="target/wasm32-unknown-unknown/wasm-release/hearthfield.wasm"
+if [ ! -f "$WASM_BIN" ]; then
+    WASM_BIN="target/wasm32-unknown-unknown/release/hearthfield.wasm"
+fi
+RAYON_NUM_THREADS=1 wasm-bindgen \
     --out-dir web \
     --target web \
     --no-typescript \
-    target/wasm32-unknown-unknown/release/hearthfield.wasm
+    "$WASM_BIN"
+
+# Optional: optimize with wasm-opt if available (saves ~40% size)
+if command -v wasm-opt &>/dev/null; then
+    echo "Optimizing with wasm-opt..."
+    wasm-opt -Oz \
+        --enable-bulk-memory \
+        --enable-sign-ext \
+        --enable-nontrapping-float-to-int \
+        --enable-mutable-globals \
+        --strip-debug \
+        --strip-producers \
+        web/hearthfield_bg.wasm \
+        -o web/hearthfield_bg.wasm
+fi
 
 # Copy assets into web folder
 echo "Copying assets..."
@@ -38,6 +57,7 @@ cp web_template/index.html web/index.html
 echo ""
 echo "=== Build complete ==="
 echo "WASM size: $(du -h web/hearthfield_bg.wasm | cut -f1)"
+echo "JS glue:   $(du -h web/hearthfield.js | cut -f1)"
 echo "Assets:    $(du -sh web/assets/ | cut -f1)"
 echo "Total:     $(du -sh web/ | cut -f1)"
 echo ""

--- a/index.html
+++ b/index.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+    <title>Hearthfield</title>
+    <link data-trunk rel="copy-dir" href="assets"/>
+    <style>
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+        html, body {
+            width: 100%; height: 100%; overflow: hidden;
+            background: #1a1a2e;
+            overscroll-behavior: none; touch-action: none;
+        }
+        canvas {
+            width: 100% !important; height: 100% !important;
+            object-fit: contain;
+            image-rendering: pixelated; image-rendering: crisp-edges;
+        }
+        @supports (-webkit-touch-callout: none) {
+            html, body { height: -webkit-fill-available; }
+        }
+    </style>
+</head>
+<body>
+    <script>
+        document.addEventListener('gesturestart', e => e.preventDefault());
+        document.addEventListener('gesturechange', e => e.preventDefault());
+        document.addEventListener('gestureend', e => e.preventDefault());
+        let audioUnlocked = false;
+        function unlockAudio() {
+            if (audioUnlocked) return;
+            const ctx = new (window.AudioContext || window.webkitAudioContext)();
+            const buf = ctx.createBuffer(1, 1, 22050);
+            const src = ctx.createBufferSource();
+            src.buffer = buf; src.connect(ctx.destination); src.start(0);
+            audioUnlocked = true;
+        }
+        document.addEventListener('touchstart', unlockAudio, { once: true });
+        document.addEventListener('click', unlockAudio, { once: true });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
- Set RAYON_NUM_THREADS=1 for wasm-bindgen to prevent rayon worker thread stack overflows when walrus parses large binaries (73K+ functions)
- Add optional wasm-opt post-processing (-Oz, ~40% size reduction)
- Fix build_wasm.sh: use --profile wasm-release directly instead of conflicting --release flag; add fallback path lookup
- Remove strip=true from wasm-release profile (strips wasm-bindgen custom sections, breaking JS glue generation)
- Downgrade wasm-bindgen lock to 0.2.100 (matches installed CLI)
- Add web/, dist/, *.zip to .gitignore (build artifacts)
- Add root index.html for trunk-based WASM builds

Final build output: 16MB WASM + 100K JS glue + 29MB assets = 32MB zip

https://claude.ai/code/session_01BvdpDYLYFtGzsQsqGfzTg5