### PR TITLE
Fix purple screen: disable tonemapping, drop wav feature, add default…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2206,12 +2206,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
 
 [[package]]
-name = "hound"
-version = "3.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62adaabb884c94955b19907d60019f4e145d091c75345379e70d1ee696f7854f"
-
-[[package]]
 name = "image"
 version = "0.25.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3324,7 +3318,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6006a627c1a38d37f3d3a85c6575418cfe34a5392d60a686d0071e1c8d427acb"
 dependencies = [
  "cpal",
- "hound",
  "lewton",
  "thiserror",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,30 +5,29 @@ edition = "2021"
 
 [dependencies]
 bevy = { version = "0.15", default-features = false, features = [
-    # Rendering
+    # Core engine
+    "bevy_asset",
+    "bevy_color",
+    "bevy_state",
+    "multi_threaded",
+    # Rendering pipeline (2D)
     "bevy_render",
     "bevy_core_pipeline",
     "bevy_sprite",
     "bevy_text",
     "bevy_ui",
+    # Windowing
     "bevy_winit",
+    "x11",
     # Audio
     "bevy_audio",
     "vorbis",
-    "wav",
-    # Asset loading
-    "bevy_asset",
+    # Image format
     "png",
-    # State management
-    "bevy_state",
-    # Scheduling
-    "multi_threaded",
-    # WebGL2 renderer for mobile WASM
+    # WASM support
     "webgl2",
-    # Desktop windowing
-    "x11",
-    # Color types
-    "bevy_color",
+    # Font fallback
+    "default_font",
 ]}
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ mod save;
 mod data;
 
 use bevy::prelude::*;
+use bevy::core_pipeline::tonemapping::Tonemapping;
 use bevy::window::{PresentMode, WindowResolution};
 
 use shared::*;
@@ -138,6 +139,7 @@ fn setup_camera(mut commands: Commands) {
     commands.spawn((
         Camera2d,
         Msaa::Off,
+        Tonemapping::None,
         Transform::from_scale(Vec3::splat(1.0 / PIXEL_SCALE)),
     ));
 }


### PR DESCRIPTION
…_font

- Add Tonemapping::None to Camera2d — pixel art doesn't need tonemapping and the LUT textures (tonemapping_luts feature) aren't included
- Remove "wav" feature — all SFX converted to .ogg in prior commit
- Add "default_font" — fallback if custom font load fails
- Verified: both native and WASM compile, 91 tests pass

https://claude.ai/code/session_01BvdpDYLYFtGzsQsqGfzTg5