### PR TITLE
Fix gray-then-purple screen: add tonemapping LUTs, error overlay

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -600,6 +600,8 @@ dependencies = [
  "derive_more",
  "futures-lite",
  "image",
+ "ktx2",
+ "ruzstd",
  "serde",
  "wgpu",
 ]
@@ -861,6 +863,7 @@ dependencies = [
  "futures-lite",
  "image",
  "js-sys",
+ "ktx2",
  "naga",
  "naga_oil",
  "nonmax",
@@ -2312,6 +2315,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
+name = "ktx2"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87d65e08a9ec02e409d27a0139eaa6b9756b4d81fe7cde71f6941a83730ce838"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3402,6 +3414,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ruzstd"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fad02996bfc73da3e301efe90b1837be9ed8f4a462b6ed410aa35d00381de89f"
+dependencies = [
+ "twox-hash",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3813,6 +3834,16 @@ name = "ttf-parser"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c591d83f69777866b9126b24c6dd9a18351f177e49d625920d19f989fd31cf8"
+
+[[package]]
+name = "twox-hash"
+version = "1.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
+dependencies = [
+ "cfg-if",
+ "static_assertions",
+]
 
 [[package]]
 name = "typeid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,10 @@ bevy = { version = "0.15", default-features = false, features = [
     "bevy_sprite",
     "bevy_text",
     "bevy_ui",
+    # Pipeline requirements (needed even with Tonemapping::None)
+    "tonemapping_luts",
+    "ktx2",
+    "zstd",
     # Windowing
     "bevy_winit",
     "x11",

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,6 +40,8 @@ fn main() {
                 })
                 .set(ImagePlugin::default_nearest()),
         )
+        // Clear color (dark navy, close to HTML background)
+        .insert_resource(ClearColor(Color::srgb(0.10, 0.10, 0.18)))
         // Game state
         .init_state::<GameState>()
         // Shared resources

--- a/web_template/index.html
+++ b/web_template/index.html
@@ -79,6 +79,41 @@
 
         .hidden { opacity: 0; pointer-events: none; }
 
+        /* Error overlay */
+        #error-overlay {
+            display: none;
+            position: fixed;
+            top: 0; left: 0; right: 0; bottom: 0;
+            background: rgba(20, 10, 30, 0.95);
+            color: #ff6b6b;
+            font-family: monospace;
+            font-size: 13px;
+            z-index: 2000;
+            padding: 20px;
+            overflow-y: auto;
+            -webkit-overflow-scrolling: touch;
+        }
+        #error-overlay h2 {
+            color: #ff6b6b;
+            margin-bottom: 10px;
+            font-size: 16px;
+        }
+        #error-overlay .error-msg {
+            background: #1a0a2e;
+            border: 1px solid #ff6b6b44;
+            border-radius: 4px;
+            padding: 8px;
+            margin-bottom: 6px;
+            word-wrap: break-word;
+            white-space: pre-wrap;
+            color: #ffaaaa;
+        }
+        #error-overlay .hint {
+            color: #aaa;
+            margin-top: 12px;
+            font-size: 12px;
+        }
+
         @supports (-webkit-touch-callout: none) {
             html, body { height: -webkit-fill-available; }
             #game-container { height: -webkit-fill-available; }
@@ -96,6 +131,56 @@
         <canvas id="game-canvas"></canvas>
     </div>
 
+    <div id="error-overlay">
+        <h2>Hearthfield Error</h2>
+        <div id="error-messages"></div>
+        <p class="hint">Screenshot this and share for debugging.<br>
+        Try refreshing or opening on a desktop browser.</p>
+    </div>
+
+    <script>
+        // Error capture (runs before anything else)
+        const errorOverlay = document.getElementById('error-overlay');
+        const errorMessages = document.getElementById('error-messages');
+        let errorCount = 0;
+
+        function showError(msg) {
+            errorCount++;
+            if (errorCount > 20) return;
+            errorOverlay.style.display = 'block';
+            const div = document.createElement('div');
+            div.className = 'error-msg';
+            div.textContent = msg;
+            errorMessages.appendChild(div);
+        }
+
+        const origError = console.error;
+        console.error = function() {
+            origError.apply(console, arguments);
+            const msg = Array.from(arguments).map(a =>
+                typeof a === 'object' ? JSON.stringify(a, null, 2) : String(a)
+            ).join(' ');
+            showError(msg);
+        };
+
+        window.addEventListener('error', (e) => {
+            showError('JS Error: ' + e.message + '\n  at ' + e.filename + ':' + e.lineno);
+        });
+
+        window.addEventListener('unhandledrejection', (e) => {
+            const reason = e.reason;
+            let msg = 'Unhandled rejection: ';
+            if (reason instanceof Error) {
+                msg += reason.message + '\n' + (reason.stack || '');
+            } else if (typeof reason === 'string') {
+                msg += reason;
+            } else {
+                msg += JSON.stringify(reason);
+            }
+            showError(msg);
+        });
+    </script>
+
     <script type="module">
         const loadingBar = document.getElementById('loading-bar');
         const loadingText = document.getElementById('loading-text');
@@ -105,6 +190,8 @@
         loadingBar.style.width = '10%';
 
         try {
+            loadingText.textContent = 'Importing module...';
+            loadingBar.style.width = '20%';
             const module = await import('./hearthfield.js');
 
             loadingText.textContent = 'Compiling WASM...';
@@ -114,7 +201,7 @@
                 setTimeout(() => reject(new Error('WASM initialization timed out (60s). Your device may not support this game.')), 60000)
             );
 
-            loadingText.textContent = 'Starting engine...';
+            loadingText.textContent = 'Starting Bevy engine...';
             loadingBar.style.width = '50%';
 
             await Promise.race([module.default(), timeout]);


### PR DESCRIPTION
- Add tonemapping_luts + ktx2 + zstd features to Cargo.toml (bevy_core_pipeline requires LUT textures at init even with Tonemapping::None — without them the pipeline panics on frame 2)
- Add explicit ClearColor(dark navy) to distinguish running-but-empty from crashed-canvas (HTML background showing through)
- Replace index.html with error overlay version: intercepts console.error, unhandled rejections, and JS errors, displaying them on-screen so mobile users can screenshot for debugging

WASM: 13MB, assets: 9.7MB, total: 23MB

https://claude.ai/code/session_01BvdpDYLYFtGzsQsqGfzTg5