### PR TITLE
Fix spatial-truth bugs (Y-sort, camera snap, coordinate contract) and add F3 debug overlay

### DIFF
--- a/src/farming/crops.rs
+++ b/src/farming/crops.rs
@@ -4,7 +4,7 @@ use bevy::prelude::*;
 use crate::shared::*;
 use super::{
     FarmEntities, CropTileEntity, PlantSeedEvent,
-    grid_to_world, crop_stage_color, crop_can_grow_in_season,
+    crop_stage_color, crop_can_grow_in_season,
 };
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -67,8 +67,9 @@ pub fn detect_seed_use(
         return;
     };
 
-    let player_gx = (logical_pos.0.x / TILE_SIZE).round() as i32;
-    let player_gy = (logical_pos.0.y / TILE_SIZE).round() as i32;
+    let g = world_to_grid(logical_pos.0.x, logical_pos.0.y);
+    let player_gx = g.x;
+    let player_gy = g.y;
 
     // Target tile is the tile the player is facing.
     let (offset_x, offset_y) = match movement.facing {
@@ -207,7 +208,7 @@ pub fn spawn_crop_entity(
 ) {
     let total_stages = crop_def.growth_days.len() as u8;
     let color = crop_stage_color(crop.current_stage, total_stages, crop.dead);
-    let translation = grid_to_world(pos.0, pos.1).with_z(Z_FARM_OVERLAY + 1.0);
+    let translation = grid_to_world_center(pos.0, pos.1).extend(Z_FARM_OVERLAY + 1.0);
 
     let entity = commands.spawn((
         Sprite {

--- a/src/farming/harvest.rs
+++ b/src/farming/harvest.rs
@@ -36,8 +36,9 @@ pub fn detect_harvest_input(
     };
 
     // Convert world position to grid.
-    let grid_x = (logical_pos.0.x / TILE_SIZE).round() as i32;
-    let grid_y = (logical_pos.0.y / TILE_SIZE).round() as i32;
+    let g = world_to_grid(logical_pos.0.x, logical_pos.0.y);
+    let grid_x = g.x;
+    let grid_y = g.y;
 
     harvest_events.send(HarvestAttemptEvent { grid_x, grid_y });
 }
@@ -216,7 +217,7 @@ fn update_crop_entity_color(
     } else {
         // Entity doesn't exist yet — spawn it.
         // We need a CropTileEntity and CropTile; both are cloneable.
-        let translation = super::grid_to_world(pos.0, pos.1).with_z(Z_FARM_OVERLAY + 1.0);
+        let translation = grid_to_world_center(pos.0, pos.1).extend(Z_FARM_OVERLAY + 1.0);
         let entity = commands.spawn((
             Sprite {
                 color,

--- a/src/farming/mod.rs
+++ b/src/farming/mod.rs
@@ -234,15 +234,6 @@ fn load_farming_atlases(
 // Shared helpers used across submodules
 // ─────────────────────────────────────────────────────────────────────────────
 
-/// Convert a grid position to a world-space translation (centre of tile).
-pub fn grid_to_world(x: i32, y: i32) -> Vec3 {
-    Vec3::new(
-        x as f32 * TILE_SIZE,
-        y as f32 * TILE_SIZE,
-        Z_FARM_OVERLAY,
-    )
-}
-
 /// Check whether the given CropDef can grow in this season.
 pub fn crop_can_grow_in_season(def: &CropDef, season: Season) -> bool {
     def.seasons.is_empty() || def.seasons.contains(&season)

--- a/src/farming/render.rs
+++ b/src/farming/render.rs
@@ -9,7 +9,7 @@ use bevy::prelude::*;
 use crate::shared::*;
 use super::{
     FarmEntities, FarmingAtlases, SoilTileEntity, CropTileEntity,
-    grid_to_world, crop_stage_color,
+    crop_stage_color,
     soil::soil_color,
 };
 
@@ -88,7 +88,8 @@ pub fn sync_soil_sprites(
         .collect();
 
     for (pos, state) in missing {
-        let translation = grid_to_world(pos.0, pos.1);
+        // Soil overlays are area fills — use corner-origin to match ground tiles
+        let translation = Vec3::new(pos.0 as f32 * TILE_SIZE, pos.1 as f32 * TILE_SIZE, Z_FARM_OVERLAY);
 
         let entity = if atlases.loaded {
             // Preferred path: use a texture atlas sprite.
@@ -227,7 +228,7 @@ pub fn sync_crop_sprites(
             .map(|d| d.growth_days.len() as u8)
             .unwrap_or(4);
 
-        let translation = grid_to_world(pos.0, pos.1).with_z(Z_FARM_OVERLAY + 1.0);
+        let translation = grid_to_world_center(pos.0, pos.1).extend(Z_FARM_OVERLAY + 1.0);
 
         let entity = if atlases.loaded && !crop.dead {
             // Preferred path: texture atlas sprite.

--- a/src/farming/soil.rs
+++ b/src/farming/soil.rs
@@ -2,7 +2,7 @@
 
 use bevy::prelude::*;
 use crate::shared::*;
-use super::{FarmEntities, SoilTileEntity, grid_to_world};
+use super::{FarmEntities, SoilTileEntity};
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Hoe — till a dirt tile
@@ -139,7 +139,8 @@ pub fn spawn_or_update_soil_entity(
         let _ = entity;
     } else {
         // Spawn a new sprite entity.
-        let translation = grid_to_world(pos.0, pos.1);
+        // Soil overlays are area fills — use corner-origin to match ground tiles
+        let translation = Vec3::new(pos.0 as f32 * TILE_SIZE, pos.1 as f32 * TILE_SIZE, Z_FARM_OVERLAY);
         let entity = commands.spawn((
             Sprite {
                 color,

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,6 +75,7 @@ fn main() {
         .init_resource::<PlayStats>()
         .init_resource::<InputBlocks>()
         .init_resource::<CutsceneQueue>()
+        .init_resource::<DebugOverlayState>()
         // Input & menu abstraction
         .init_resource::<PlayerInput>()
         .init_resource::<InputContext>()

--- a/src/npcs/schedule.rs
+++ b/src/npcs/schedule.rs
@@ -80,8 +80,9 @@ pub fn update_npc_schedules(
 
         // Only update target if on the right map
         if entry.map == current_map {
-            let target_x = entry.x as f32 * TILE_SIZE;
-            let target_y = -(entry.y as f32 * TILE_SIZE);
+            let wc = grid_to_world_center(entry.x, entry.y);
+            let target_x = wc.x;
+            let target_y = wc.y;
 
             // Only set moving if not already at target
             let dx = target_x - logical_pos.0.x;

--- a/src/npcs/spawning.rs
+++ b/src/npcs/spawning.rs
@@ -123,8 +123,9 @@ pub fn spawn_npcs_for_map(
             continue;
         }
 
-        let world_x = entry.x as f32 * TILE_SIZE;
-        let world_y = -(entry.y as f32 * TILE_SIZE);
+        let wc = grid_to_world_center(entry.x, entry.y);
+        let world_x = wc.x;
+        let world_y = wc.y;
         let color = npc_color(npc_id);
 
         // Use atlas sprite with tint color to differentiate NPCs visually.

--- a/src/player/camera.rs
+++ b/src/player/camera.rs
@@ -21,6 +21,11 @@ pub fn camera_follow_player(
     let target_x = logical_pos.0.x.round();
     let target_y = logical_pos.0.y.round();
 
-    cam_tf.translation.x += (target_x - cam_tf.translation.x) * t;
-    cam_tf.translation.y += (target_y - cam_tf.translation.y) * t;
+    // Lerp in float space (smooth)
+    let smooth_x = cam_tf.translation.x + (target_x - cam_tf.translation.x) * t;
+    let smooth_y = cam_tf.translation.y + (target_y - cam_tf.translation.y) * t;
+
+    // Snap to integer pixels for the actual transform (prevents sub-pixel blur)
+    cam_tf.translation.x = smooth_x.round();
+    cam_tf.translation.y = smooth_y.round();
 }

--- a/src/player/interaction.rs
+++ b/src/player/interaction.rs
@@ -1,6 +1,6 @@
 use bevy::prelude::*;
 use crate::shared::*;
-use super::{grid_to_world, CollisionMap};
+use super::CollisionMap;
 
 // Default energy restored by an edible item when no registry entry is found.
 const DEFAULT_FOOD_ENERGY: f32 = 20.0;
@@ -159,9 +159,9 @@ pub fn handle_map_transition(
     player_state.current_map = ev.to_map;
 
     // Reposition player to the target tile.
-    let (wx, wy) = grid_to_world(ev.to_x, ev.to_y);
-    logical_pos.0.x = wx;
-    logical_pos.0.y = wy;
+    let wc = grid_to_world_center(ev.to_x, ev.to_y);
+    logical_pos.0.x = wc.x;
+    logical_pos.0.y = wc.y;
     grid_pos.x = ev.to_x;
     grid_pos.y = ev.to_y;
 
@@ -297,9 +297,9 @@ pub fn handle_day_end(
         player_state.current_map = MapId::PlayerHouse;
 
         if let Ok((mut logical_pos, mut grid_pos)) = query.get_single_mut() {
-            let (wx, wy) = grid_to_world(bed_gx, bed_gy);
-            logical_pos.0.x = wx;
-            logical_pos.0.y = wy;
+            let wc = grid_to_world_center(bed_gx, bed_gy);
+            logical_pos.0.x = wc.x;
+            logical_pos.0.y = wc.y;
             grid_pos.x = bed_gx;
             grid_pos.y = bed_gy;
         }

--- a/src/player/mod.rs
+++ b/src/player/mod.rs
@@ -142,22 +142,6 @@ pub fn stamina_cost(tool: &ToolKind) -> f32 {
     }
 }
 
-/// Convert world-space pixel coordinates to grid position.
-pub fn world_to_grid(x: f32, y: f32) -> (i32, i32) {
-    (
-        (x / TILE_SIZE).floor() as i32,
-        (y / TILE_SIZE).floor() as i32,
-    )
-}
-
-/// Convert grid coordinates to world-space pixel position (tile center).
-pub fn grid_to_world(gx: i32, gy: i32) -> (f32, f32) {
-    (
-        gx as f32 * TILE_SIZE + TILE_SIZE * 0.5,
-        gy as f32 * TILE_SIZE + TILE_SIZE * 0.5,
-    )
-}
-
 /// The ordered list of tools for cycling with Q/E.
 pub const TOOL_ORDER: [ToolKind; 6] = [
     ToolKind::Hoe,

--- a/src/player/movement.rs
+++ b/src/player/movement.rs
@@ -1,6 +1,6 @@
 use bevy::prelude::*;
 use crate::shared::*;
-use super::{CollisionMap, DistanceAnimator, world_to_grid};
+use super::{CollisionMap, DistanceAnimator};
 
 /// Core movement system — reads input, applies velocity to LogicalPosition,
 /// updates facing direction, snaps grid position, and checks collisions.
@@ -52,9 +52,9 @@ pub fn player_movement(
             logical_pos.0.y = candidate_y;
         }
 
-        let (gx, gy) = world_to_grid(logical_pos.0.x, logical_pos.0.y);
-        grid_pos.x = gx;
-        grid_pos.y = gy;
+        let g = world_to_grid(logical_pos.0.x, logical_pos.0.y);
+        grid_pos.x = g.x;
+        grid_pos.y = g.y;
     } else {
         movement.is_moving = false;
     }
@@ -129,7 +129,8 @@ fn is_blocked(
     farm_state: &FarmState,
     player_state: &PlayerState,
 ) -> bool {
-    let (gx, gy) = world_to_grid(wx, wy);
+    let g = world_to_grid(wx, wy);
+    let (gx, gy) = (g.x, g.y);
 
     if collision_map.initialised && collision_map.solid_tiles.contains(&(gx, gy)) {
         return true;

--- a/src/player/spawn.rs
+++ b/src/player/spawn.rs
@@ -21,8 +21,9 @@ pub fn spawn_player(
         return;
     }
 
-    let world_x = SPAWN_GRID_X as f32 * TILE_SIZE + TILE_SIZE * 0.5;
-    let world_y = SPAWN_GRID_Y as f32 * TILE_SIZE + TILE_SIZE * 0.5;
+    let spawn = grid_to_world_center(SPAWN_GRID_X, SPAWN_GRID_Y);
+    let world_x = spawn.x;
+    let world_y = spawn.y;
 
     // Load the character spritesheet.
     // Sheet is 192×192, laid out as a 4×4 grid of 48×48 frames:

--- a/src/player/tool_anim.rs
+++ b/src/player/tool_anim.rs
@@ -1,6 +1,6 @@
 use bevy::prelude::*;
 use crate::shared::*;
-use super::{ActionSpriteData, PlayerSpriteData, facing_offset, world_to_grid};
+use super::{ActionSpriteData, PlayerSpriteData, facing_offset};
 
 // Action atlas base indices (2 cols × 12 rows, indexed left-to-right, top-to-bottom)
 // Each tool gets 4 frames (2 frames × 2 rows per tool direction).
@@ -59,7 +59,8 @@ pub fn animate_tool_use(
 
                 // Emit impact event on frame 2 — target the faced tile, not the player's tile
                 if frame == 2 {
-                    let (px, py) = world_to_grid(logical_pos.0.x, logical_pos.0.y);
+                    let g = world_to_grid(logical_pos.0.x, logical_pos.0.y);
+                    let (px, py) = (g.x, g.y);
                     let (dx, dy) = facing_offset(&movement.facing);
                     impact_events.send(ToolImpactEvent {
                         tool,

--- a/src/player/tools.rs
+++ b/src/player/tools.rs
@@ -75,7 +75,8 @@ pub fn tool_use(
     }
 
     // Calculate target tile: player's current grid + facing offset.
-    let (px, py) = super::world_to_grid(logical_pos.0.x, logical_pos.0.y);
+    let g = world_to_grid(logical_pos.0.x, logical_pos.0.y);
+    let (px, py) = (g.x, g.y);
     let (dx, dy) = facing_offset(&movement.facing);
     let target_x = px + dx;
     let target_y = py + dy;

--- a/src/shared/mod.rs
+++ b/src/shared/mod.rs
@@ -1875,6 +1875,39 @@ fn facing_delta(facing: Facing) -> (i32, i32) {
     }
 }
 
+// ═══════════════════════════════════════════════════════════════════════
+// COORDINATE CONVERSION (one true convention)
+// ═══════════════════════════════════════════════════════════════════════
+
+/// Convert grid coordinates to world-space position (tile CENTER).
+/// This is the ONLY sanctioned grid→world conversion in the codebase.
+pub fn grid_to_world_center(gx: i32, gy: i32) -> Vec2 {
+    Vec2::new(
+        gx as f32 * TILE_SIZE + TILE_SIZE * 0.5,
+        gy as f32 * TILE_SIZE + TILE_SIZE * 0.5,
+    )
+}
+
+/// Convert world-space position to grid coordinates.
+/// Uses floor() — a point at (15.9, 31.1) with TILE_SIZE=16 is tile (0, 1).
+/// This is the ONLY sanctioned world→grid conversion in the codebase.
+pub fn world_to_grid(wx: f32, wy: f32) -> IVec2 {
+    IVec2::new(
+        (wx / TILE_SIZE).floor() as i32,
+        (wy / TILE_SIZE).floor() as i32,
+    )
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// DEBUG OVERLAY
+// ═══════════════════════════════════════════════════════════════════════
+
+/// Toggle for debug overlay visibility.
+#[derive(Resource, Default)]
+pub struct DebugOverlayState {
+    pub visible: bool,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/ui/debug_overlay.rs
+++ b/src/ui/debug_overlay.rs
@@ -1,0 +1,94 @@
+use bevy::prelude::*;
+use crate::shared::*;
+use crate::player::DistanceAnimator;
+
+/// Marker for the debug overlay root node.
+#[derive(Component)]
+pub struct DebugOverlayRoot;
+
+/// Marker for the debug text.
+#[derive(Component)]
+pub struct DebugOverlayText;
+
+/// Toggle debug overlay with F3.
+pub fn toggle_debug_overlay(
+    keys: Res<ButtonInput<KeyCode>>,
+    mut debug_state: ResMut<DebugOverlayState>,
+) {
+    if keys.just_pressed(KeyCode::F3) {
+        debug_state.visible = !debug_state.visible;
+    }
+}
+
+/// Spawn the debug overlay UI (runs once at startup).
+pub fn spawn_debug_overlay(mut commands: Commands) {
+    commands.spawn((
+        DebugOverlayRoot,
+        Node {
+            position_type: PositionType::Absolute,
+            left: Val::Px(8.0),
+            top: Val::Px(8.0),
+            padding: UiRect::all(Val::Px(4.0)),
+            ..default()
+        },
+        BackgroundColor(Color::srgba(0.0, 0.0, 0.0, 0.7)),
+        Visibility::Hidden,
+    )).with_children(|parent| {
+        parent.spawn((
+            DebugOverlayText,
+            Text::new("Debug"),
+            TextFont {
+                font_size: 14.0,
+                ..default()
+            },
+            TextColor(Color::srgb(0.0, 1.0, 0.0)),
+        ));
+    });
+}
+
+/// Update debug overlay content and visibility.
+pub fn update_debug_overlay(
+    debug_state: Res<DebugOverlayState>,
+    mut overlay_query: Query<&mut Visibility, With<DebugOverlayRoot>>,
+    mut text_query: Query<&mut Text, With<DebugOverlayText>>,
+    player_query: Query<(
+        &LogicalPosition,
+        &GridPosition,
+        &PlayerMovement,
+        &DistanceAnimator,
+        &Sprite,
+    ), With<Player>>,
+    camera_query: Query<&Transform, With<Camera2d>>,
+) {
+    let Ok(mut vis) = overlay_query.get_single_mut() else { return };
+
+    if !debug_state.visible {
+        *vis = Visibility::Hidden;
+        return;
+    }
+    *vis = Visibility::Inherited;
+
+    let Ok(mut text) = text_query.get_single_mut() else { return };
+
+    let mut lines = Vec::new();
+
+    if let Ok((pos, grid, movement, anim, sprite)) = player_query.get_single() {
+        let atlas_idx = sprite.texture_atlas.as_ref().map(|a| a.index).unwrap_or(0);
+        let ysort_z = Z_ENTITY_BASE - pos.0.y * Z_Y_SORT_SCALE;
+
+        lines.push(format!("Pos: ({:.1}, {:.1})", pos.0.x, pos.0.y));
+        lines.push(format!("Grid: ({}, {})", grid.x, grid.y));
+        lines.push(format!("Facing: {:?}", movement.facing));
+        lines.push(format!("Anim: {:?}", movement.anim_state));
+        lines.push(format!("Atlas: {}", atlas_idx));
+        lines.push(format!("Dist frame: {}/{}", anim.current_frame, anim.frames_per_row));
+        lines.push(format!("Dist budget: {:.1}", anim.distance_budget));
+        lines.push(format!("Y-sort Z: {:.2}", ysort_z));
+    }
+
+    if let Ok(cam_tf) = camera_query.get_single() {
+        lines.push(format!("Cam: ({:.1}, {:.1})", cam_tf.translation.x, cam_tf.translation.y));
+    }
+
+    **text = lines.join("\n");
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,6 +1,7 @@
 mod audio;
 mod chest_screen;
 mod crafting_screen;
+pub mod debug_overlay;
 mod dialogue_box;
 mod hud;
 mod input;
@@ -216,6 +217,13 @@ impl Plugin for UiPlugin {
             )
                 .run_if(in_state(GameState::Paused)),
         );
+
+        // ─── DEBUG OVERLAY (always available, toggled by F3) ───
+        app.add_systems(Startup, debug_overlay::spawn_debug_overlay);
+        app.add_systems(Update, (
+            debug_overlay::toggle_debug_overlay,
+            debug_overlay::update_debug_overlay,
+        ));
 
         // ─── CHEST SCREEN (reactive overlay during Playing state) ───
         app.add_systems(

--- a/src/world/chests.rs
+++ b/src/world/chests.rs
@@ -119,8 +119,9 @@ pub fn place_chest(
         return;
     };
 
-    let px = (transform.translation.x / TILE_SIZE).floor() as i32;
-    let py = (transform.translation.y / TILE_SIZE).floor() as i32;
+    let pg = world_to_grid(transform.translation.x, transform.translation.y);
+    let px = pg.x;
+    let py = pg.y;
     let (dx, dy) = facing_offset(&movement.facing);
     let target_x = px + dx;
     let target_y = py + dy;

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -711,8 +711,9 @@ fn handle_season_change(
         if let Some(ref map_def) = world_map.map_def {
             for (transform, mut sprite) in tile_query.iter_mut() {
                 // Convert world position back to grid position
-                let gx = (transform.translation.x / TILE_SIZE).round() as i32;
-                let gy = (transform.translation.y / TILE_SIZE).round() as i32;
+                let g = world_to_grid(transform.translation.x, transform.translation.y);
+                let gx = g.x;
+                let gy = g.y;
 
                 let tile = map_def.get_tile(gx, gy);
 

--- a/src/world/objects.rs
+++ b/src/world/objects.rs
@@ -247,11 +247,12 @@ pub fn spawn_world_objects(
             );
             sprite.custom_size = Some(size);
 
+            let wc = grid_to_world_center(placement.x, placement.y);
             commands.spawn((
                 sprite,
                 Transform::from_translation(Vec3::new(
-                    placement.x as f32 * TILE_SIZE,
-                    placement.y as f32 * TILE_SIZE + y_offset,
+                    wc.x,
+                    wc.y + y_offset,
                     Z_ENTITY_BASE,
                 )),
                 WorldObject,
@@ -260,6 +261,7 @@ pub fn spawn_world_objects(
             ));
         } else {
             // Fallback: colored rectangle if atlases failed to load
+            let wc = grid_to_world_center(placement.x, placement.y);
             commands.spawn((
                 Sprite {
                     color: kind.color(),
@@ -267,8 +269,8 @@ pub fn spawn_world_objects(
                     ..default()
                 },
                 Transform::from_translation(Vec3::new(
-                    placement.x as f32 * TILE_SIZE,
-                    placement.y as f32 * TILE_SIZE + y_offset,
+                    wc.x,
+                    wc.y + y_offset,
                     Z_ENTITY_BASE,
                 )),
                 WorldObject,
@@ -389,11 +391,12 @@ pub fn handle_tool_use_on_objects(
                                 stump_sprite.custom_size =
                                     Some(WorldObjectKind::Stump.sprite_size());
 
+                                let stump_wc = grid_to_world_center(obj_data.grid_x, obj_data.grid_y);
                                 commands.spawn((
                                     stump_sprite,
                                     Transform::from_translation(Vec3::new(
-                                        obj_data.grid_x as f32 * TILE_SIZE,
-                                        obj_data.grid_y as f32 * TILE_SIZE,
+                                        stump_wc.x,
+                                        stump_wc.y,
                                         Z_ENTITY_BASE,
                                     )),
                                     WorldObject,
@@ -402,6 +405,7 @@ pub fn handle_tool_use_on_objects(
                                 ));
                             } else {
                                 // Fallback: colored rectangle
+                                let stump_wc = grid_to_world_center(obj_data.grid_x, obj_data.grid_y);
                                 commands.spawn((
                                     Sprite {
                                         color: WorldObjectKind::Stump.color(),
@@ -409,8 +413,8 @@ pub fn handle_tool_use_on_objects(
                                         ..default()
                                     },
                                     Transform::from_translation(Vec3::new(
-                                        obj_data.grid_x as f32 * TILE_SIZE,
-                                        obj_data.grid_y as f32 * TILE_SIZE,
+                                        stump_wc.x,
+                                        stump_wc.y,
                                         Z_ENTITY_BASE,
                                     )),
                                     WorldObject,
@@ -507,6 +511,7 @@ pub fn spawn_forageables(
         let idx = ((day as usize).wrapping_mul(7).wrapping_add(i.wrapping_mul(13))) % forageables.len();
         let (item_id, color) = &forageables[idx];
 
+        let fwc = grid_to_world_center(gx, gy);
         commands.spawn((
             Sprite {
                 color: *color,
@@ -514,8 +519,8 @@ pub fn spawn_forageables(
                 ..default()
             },
             Transform::from_translation(Vec3::new(
-                gx as f32 * TILE_SIZE,
-                gy as f32 * TILE_SIZE,
+                fwc.x,
+                fwc.y,
                 Z_ENTITY_BASE,
             )),
             WorldObject,
@@ -633,16 +638,15 @@ pub fn spawn_daily_weeds(
             }
 
             // Spawn the weed entity
-            let wx = x as f32 * TILE_SIZE;
-            let wy = y as f32 * TILE_SIZE;
+            let wwc = grid_to_world_center(x, y);
             commands.spawn((
                 Sprite {
                     color: Color::srgb(0.25, 0.55, 0.2),
                     custom_size: Some(Vec2::new(TILE_SIZE * 0.5, TILE_SIZE * 0.5)),
                     ..default()
                 },
-                Transform::from_translation(Vec3::new(wx, wy, Z_ENTITY_BASE)),
-                LogicalPosition(Vec2::new(wx, wy)),
+                Transform::from_translation(Vec3::new(wwc.x, wwc.y, Z_ENTITY_BASE)),
+                LogicalPosition(Vec2::new(wwc.x, wwc.y)),
                 YSorted,
                 Weed {
                     grid_x: x,
@@ -781,11 +785,12 @@ pub fn regrow_trees_on_season_change(
                 );
                 sprite.custom_size = Some(size);
 
+                let rwc = grid_to_world_center(x, y);
                 commands.spawn((
                     sprite,
                     Transform::from_translation(Vec3::new(
-                        x as f32 * TILE_SIZE,
-                        y as f32 * TILE_SIZE + y_offset,
+                        rwc.x,
+                        rwc.y + y_offset,
                         Z_ENTITY_BASE,
                     )),
                     WorldObject,
@@ -793,6 +798,7 @@ pub fn regrow_trees_on_season_change(
                     data,
                 ));
             } else {
+                let rwc = grid_to_world_center(x, y);
                 commands.spawn((
                     Sprite {
                         color: kind.color(),
@@ -800,8 +806,8 @@ pub fn regrow_trees_on_season_change(
                         ..default()
                     },
                     Transform::from_translation(Vec3::new(
-                        x as f32 * TILE_SIZE,
-                        y as f32 * TILE_SIZE + y_offset,
+                        rwc.x,
+                        rwc.y + y_offset,
                         Z_ENTITY_BASE,
                     )),
                     WorldObject,

--- a/src/world/ysort.rs
+++ b/src/world/ysort.rs
@@ -4,20 +4,39 @@ use crate::shared::*;
 /// Syncs LogicalPosition → Transform with pixel rounding and Y-sort Z.
 /// Runs in PostUpdate AFTER all movement systems.
 ///
-/// For Y-sorted entities: rounds XY, computes Z from Y position.
+/// For Y-sorted entities with LogicalPosition: rounds XY, computes Z from logical Y.
 /// For non-Y-sorted entities with LogicalPosition: just rounds XY, keeps Z.
+/// For Y-sorted entities WITHOUT LogicalPosition (static objects): computes Z from current Y.
 pub fn sync_position_and_ysort(
-    mut with_ysort: Query<(&LogicalPosition, &mut Transform), With<YSorted>>,
-    mut without_ysort: Query<(&LogicalPosition, &mut Transform), Without<YSorted>>,
+    mut ysorted_with_pos: Query<
+        (&LogicalPosition, &mut Transform),
+        With<YSorted>,
+    >,
+    mut not_ysorted_with_pos: Query<
+        (&LogicalPosition, &mut Transform),
+        Without<YSorted>,
+    >,
+    mut ysorted_no_pos: Query<
+        &mut Transform,
+        (With<YSorted>, Without<LogicalPosition>),
+    >,
 ) {
-    for (logical_pos, mut transform) in &mut with_ysort {
+    // Moving Y-sorted entities: pixel-snap XY, compute Z from logical Y
+    for (logical_pos, mut transform) in &mut ysorted_with_pos {
         transform.translation.x = logical_pos.0.x.round();
         transform.translation.y = logical_pos.0.y.round();
         transform.translation.z = Z_ENTITY_BASE - logical_pos.0.y * Z_Y_SORT_SCALE;
     }
 
-    for (logical_pos, mut transform) in &mut without_ysort {
+    // Non-Y-sorted entities with LogicalPosition: pixel-snap XY, keep Z
+    for (logical_pos, mut transform) in &mut not_ysorted_with_pos {
         transform.translation.x = logical_pos.0.x.round();
         transform.translation.y = logical_pos.0.y.round();
+    }
+
+    // Static Y-sorted entities (no LogicalPosition): compute Z from current Y
+    // Do NOT touch XY — these were placed correctly at spawn
+    for mut transform in &mut ysorted_no_pos {
+        transform.translation.z = Z_ENTITY_BASE - transform.translation.y * Z_Y_SORT_SCALE;
     }
 }


### PR DESCRIPTION
Three rendering bugs fixed:
- Bug B: Static world objects (trees, rocks) now get correct Z from Y position
  via a third query in sync_position_and_ysort for YSorted entities without
  LogicalPosition
- Bug C: Camera lerp output is now pixel-snapped after interpolation,
  eliminating sub-pixel shimmer with nearest-neighbor filtering
- Bug A: Unified coordinate contract — shared grid_to_world_center() and
  world_to_grid() replace 3 divergent domain-local helpers; all .round()
  world-to-grid conversions replaced with .floor(); NPC Y negation removed

New F3 debug overlay shows player position, grid coords, animation state,
atlas index, distance animator, Y-sort Z, and camera position.

91 tests pass, 0 compilation errors.

https://claude.ai/code/session_014ZF2X1f5KsSRoAmsCD2PrW