### PR TITLE
Fix 3 follow-up Copilot review comments

### DIFF
--- a/src/player/interact_dispatch.rs
+++ b/src/player/interact_dispatch.rs
@@ -59,6 +59,7 @@ pub fn dispatch_world_interaction(
         InteractionKind::ShippingBin => {
             let slot_idx = inventory.selected_slot;
             let Some(ref slot) = inventory.slots.get(slot_idx).and_then(|s| s.as_ref()) else {
+                interaction_claimed.0 = true;
                 toast_events.send(ToastEvent {
                     message: "No item selected to ship.".into(),
                     duration_secs: 2.0,

--- a/src/save/mod.rs
+++ b/src/save/mod.rs
@@ -148,7 +148,7 @@ impl Default for SessionTimer {
 // SYSTEM PARAM BUNDLES (to stay within Bevy's 16-param limit)
 // ═══════════════════════════════════════════════════════════════════════
 
-/// Read-only bundle of the 10 extended resources (for saving).
+/// Read-only bundle of extended resources (for saving).
 #[derive(SystemParam)]
 struct ExtendedResources<'w> {
     pub house_state: Res<'w, HouseState>,

--- a/src/ui/debug_overlay.rs
+++ b/src/ui/debug_overlay.rs
@@ -22,8 +22,8 @@ pub fn toggle_debug_overlay(
 }
 
 /// Spawn the debug overlay UI (runs once at startup).
-pub fn spawn_debug_overlay(mut commands: Commands, font_handle: Option<Res<UiFontHandle>>) {
-    let font = font_handle.map(|h| h.0.clone()).unwrap_or_default();
+pub fn spawn_debug_overlay(mut commands: Commands, font_handle: Res<UiFontHandle>) {
+    let font = font_handle.0.clone();
     commands.spawn((
         DebugOverlayRoot,
         Node {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -240,7 +240,7 @@ impl Plugin for UiPlugin {
 
         // ─── DEBUG OVERLAY (always available, toggled by F3) ───
         app.init_resource::<DebugOverlayState>();
-        app.add_systems(Startup, debug_overlay::spawn_debug_overlay);
+        app.add_systems(Startup, debug_overlay::spawn_debug_overlay.after(load_ui_font));
         app.add_systems(Update, (
             debug_overlay::toggle_debug_overlay,
             debug_overlay::update_debug_overlay,


### PR DESCRIPTION
- spawn_debug_overlay: require Res<UiFontHandle> instead of Option, add .after(load_ui_font) ordering to guarantee font is available
- ShippingBin: claim interaction even when no item is selected, so other F-key systems don't fire a secondary interaction on same frame
- ExtendedResources: drop stale "10 resources" from doc comment

https://claude.ai/code/session_01HMkrhUxy5vW2xK6cWuGepw